### PR TITLE
fix added /

### DIFF
--- a/admin-frontend/src/pages/ViewListing.tsx
+++ b/admin-frontend/src/pages/ViewListing.tsx
@@ -125,7 +125,7 @@ export default function ViewListing() {
                             className="detail-btn-secondary"
                             onClick={() => {
                                 const frontendUrl = import.meta.env.VITE_FRONTEND_URL || 'http://localhost:5173';
-                                window.open(`${frontendUrl}/item-details/${listing.listing_id}`, '_blank');
+                                window.open(`${frontendUrl}item-details/${listing.listing_id}`, '_blank');
                             }}
                         >
                             View Listing


### PR DESCRIPTION
When navigating to a listing from Admin to Client portal, the link won't work because there is an extra /
<img width="826" height="117" alt="image" src="https://github.com/user-attachments/assets/70e6722a-7a27-40e0-8cf9-77d8d965f7bd" />
